### PR TITLE
Makes package.json types value reference the *.d.ts file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "gatsby-plugin-realfavicongenerator",
   "version": "0.1.2",
   "main": "index.js",
+  "types": "index.d.ts",
   "author": "Kim Jeker <github@kije.ch>",
   "bugs": {
     "url": "https://github.com/kije/gatsby-plugin-realfavicongenerator/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-realfavicongenerator",
   "version": "0.1.2",
-  "main": "index.js",
+  "main": "index.ts",
   "types": "index.d.ts",
   "author": "Kim Jeker <github@kije.ch>",
   "bugs": {


### PR DESCRIPTION
Fixes installation when used through workspaces.

ERROR #10226 API.CONFIG.LOADING

Couldn't find the "gatsby-plugin-realfavicongenerator" plugin declared in
"/Users/gcutrini/dev/@openeventkit/event-site/gatsby-config.js".

Tried looking for an installed package in the following paths:

/Users/gcutrini/dev/node_modules/gatsby/dist/bootstrap/load-themes/node_modules/gatsby-plugin-realfavicongenerator
/Users/gcutrini/dev/node_modules/gatsby/dist/bootstrap/node_modules/gatsby-plugin-realfavicongenerator
/Users/gcutrini/dev/node_modules/gatsby/dist/node_modules/gatsby-plugin-realfavicongenerator
/Users/gcutrini/dev/node_modules/gatsby/node_modules/gatsby-plugin-realfavicongenerator
/Users/gcutrini/dev/node_modules/gatsby-plugin-realfavicongenerator
/Users/gcutrini/dev/node_modules/gatsby-plugin-realfavicongenerator
/Users/gcutrini/node_modules/gatsby-plugin-realfavicongenerator
/Users/node_modules/gatsby-plugin-realfavicongenerator
/node_modules/gatsby-plugin-realfavicongenerator